### PR TITLE
Run pattern matching experiment as integration test

### DIFF
--- a/examples/pattern_matching_showcase/experiment.test.sh
+++ b/examples/pattern_matching_showcase/experiment.test.sh
@@ -1,0 +1,2 @@
+mpirun -n 3 music `readlink -f run.music` TEST_MODE
+

--- a/examples/pattern_matching_showcase/experiment.test.sh
+++ b/examples/pattern_matching_showcase/experiment.test.sh
@@ -1,2 +1,0 @@
-mpirun -n 3 music `readlink -f run.music` TEST_MODE
-

--- a/examples/pattern_matching_showcase/python/config.py
+++ b/examples/pattern_matching_showcase/python/config.py
@@ -6,6 +6,7 @@ import os
 import math
 import logging
 import time
+import sys
 
 
 def s_to_ms(seconds):
@@ -118,6 +119,9 @@ music_zmq_proxy_config = {
 network_node_time_step = 0.001
 total_simulation_time = 100000.0
 synapse_update_interval = 0.1
+
+if len(sys.argv) > 1 and "TEST_MODE" in sys.argv[1:]:
+    total_simulation_time = 10.0
 
 nest_n_threads = 1 # None -> auto; Integer -> according fixed number of threads
 

--- a/examples/pattern_matching_showcase/python/network_node.py
+++ b/examples/pattern_matching_showcase/python/network_node.py
@@ -1,12 +1,12 @@
 #! /usr/bin/python
 
 import logging
+from config import *
 
 import nest
 import numpy as np
 from mpi4py import MPI
 
-from config import *
 from snn_utils.comm.music.node.nest import PyNestNode
 
 logger = logging.getLogger(__name__)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -27,3 +27,6 @@ add_test( NAME test_tracing_node COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_t
 add_test( NAME test_reward_synapse COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_reward_synapse.py )
 add_test( NAME test_reward_synapse_io COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_reward_synapse_io.py )
 add_test( NAME test_reward_in_proxy COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_reward_in_proxy/test.py )
+
+# Integration Tests
+add_test( NAME test_pattern_matching COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_pattern_matching.py )

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -29,4 +29,4 @@ add_test( NAME test_reward_synapse_io COMMAND python ${CMAKE_CURRENT_LIST_DIR}/t
 add_test( NAME test_reward_in_proxy COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_reward_in_proxy/test.py )
 
 # Integration Tests
-add_test( NAME test_pattern_matching COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_pattern_matching.py )
+add_test( NAME test_music_integration COMMAND python ${CMAKE_CURRENT_LIST_DIR}/test_music_integration.py )

--- a/unittests/test_music_integration.py
+++ b/unittests/test_music_integration.py
@@ -5,11 +5,10 @@ import subprocess
 import os
 
 
-class PatternMatchingTest(unittest.TestCase):
-    def test(self):
+class MusicIntegrationTest(unittest.TestCase):
+    def test_pattern_matching(self):
         showcase_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'examples', 'pattern_matching_showcase')
-        print(showcase_path)
-        subprocess.check_call(["mpirun", "-np", "3", "music", "run.music", "TEST_MODE"], cwd=showcase_path)
+        subprocess.check_call(["sh", "experiment.test.sh"], cwd=showcase_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/test_pattern_matching.py
+++ b/unittests/test_pattern_matching.py
@@ -1,0 +1,15 @@
+#! /usr/bin/python
+
+import unittest
+import subprocess
+import os
+
+
+class PatternMatchingTest(unittest.TestCase):
+    def test(self):
+        showcase_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'examples', 'pattern_matching_showcase')
+        print(showcase_path)
+        subprocess.check_call(["mpirun", "-np", "3", "music", "run.music", "TEST_MODE"], cwd=showcase_path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- config.py uses `sys.argv` to set the simulation time
- `config` has to be imported before `nest`, otherwise `sys.argv` gets consumed
- The actual test requires a hard-coded path to reach the showcase
- Should we use a helper script, like `experiment.test.sh` to wrap the actual mpi call?

@kappeld @anandtrex