### PR TITLE
Fix to Issue #17

### DIFF
--- a/examples/pattern_matching_showcase/python/config.py
+++ b/examples/pattern_matching_showcase/python/config.py
@@ -142,7 +142,7 @@ synapse_update_interval = 0.1
 if len(sys.argv) > 1 and "TEST_MODE" in sys.argv[1:]:
     total_simulation_time = 20.0
 
-nest_n_threads = 1  # None -> auto; Integer -> according fixed number of threads
+nest_n_threads = 16  # None -> auto; Integer -> according fixed number of threads
 
 # EXPERIMENT
 

--- a/examples/pattern_matching_showcase/python/config.py
+++ b/examples/pattern_matching_showcase/python/config.py
@@ -142,7 +142,7 @@ synapse_update_interval = 0.1
 if len(sys.argv) > 1 and "TEST_MODE" in sys.argv[1:]:
     total_simulation_time = 20.0
 
-nest_n_threads = 16  # None -> auto; Integer -> according fixed number of threads
+nest_n_threads = 4  # None -> auto; Integer -> according fixed number of threads
 
 # EXPERIMENT
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,9 @@ set( MODULE_VERSION "${MODULE_VERSION_MAJOR}.${MODULE_VERSION_MINOR}" )
 set( MODULE_HEADER ${MODULE_NAME}.h )
 
 set( MODULE_SOURCES
+    spore.h
     sporemodule.cpp sporemodule.h
+    spore_names.cpp spore_names.h
     connection_updater.cpp connection_updater.h
     connection_data_logger.cpp connection_data_logger.h
     tracing_node.cpp tracing_node.h

--- a/src/connection_data_logger.cpp
+++ b/src/connection_data_logger.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "connection_data_logger.h"
+#include "spore_names.h"
 
 #include "dictutils.h"
 #include "exceptions.h"
@@ -67,11 +68,11 @@ void ConnectionDataLoggerBase::get_status(DictionaryDatum& d, recorder_port port
     assert(port < recorder_data_.size());
     ConnectionDataLoggerBase::RecorderData& recorder = *recorder_data_[port];
 
-    (*d)["recorder_times"] = recorder.recorder_times_;
+    (*d)[names::recorder_times] = recorder.recorder_times_;
 
     for (size_t i = 0; i < recorder_info_.size(); i++)
     {
-        (*d)[recorder_info_[i].name_ + "_values"] = recorder.recorder_values_[i];
+        (*d)[recorder_info_[i].get_name()] = recorder.recorder_values_[i];
     }
 }
 
@@ -85,7 +86,7 @@ void ConnectionDataLoggerBase::get_status(DictionaryDatum& d, recorder_port port
 void ConnectionDataLoggerBase::set_status(const DictionaryDatum& d, recorder_port& port)
 {
     double interval = 0.0;
-    updateValue<double>(d, "recorder_interval", interval);
+    updateValue<double>(d, names::recorder_interval, interval);
 
     if (interval > 0.0 && (port == nest::invalid_index))
         port = add_recordable_connection();
@@ -98,7 +99,7 @@ void ConnectionDataLoggerBase::set_status(const DictionaryDatum& d, recorder_por
     recorder_data_[port]->interval_ = interval;
 
     bool reset_recorder = false;
-    updateValue<bool>(d, "reset_recorder", reset_recorder);
+    updateValue<bool>(d, names::reset_recorder, reset_recorder);
 
     if (reset_recorder)
     {

--- a/src/connection_data_logger.cpp
+++ b/src/connection_data_logger.cpp
@@ -70,9 +70,9 @@ void ConnectionDataLoggerBase::get_status(DictionaryDatum& d, recorder_port port
 
     (*d)[names::recorder_times] = recorder.recorder_times_;
 
-    for (size_t i = 0; i < recorder_info_.size(); i++)
+    for (size_t i = 0; i < recorder_names_.size(); i++)
     {
-        (*d)[recorder_info_[i].get_name()] = recorder.recorder_values_[i];
+        (*d)[recorder_names_[i]] = recorder.recorder_values_[i];
     }
 }
 
@@ -117,7 +117,7 @@ ConnectionDataLoggerBase::recorder_port ConnectionDataLoggerBase::add_recordable
     if (recorder_data_.size() == nest::invalid_index)
         throw nest::BadProperty("Maximum number of recorders reached.");
 
-    recorder_data_.push_back(new RecorderData(recorder_info_.size()));
+    recorder_data_.push_back(new RecorderData(recorder_names_.size()));
     return recorder_data_.size() - 1;
 }
 

--- a/src/connection_data_logger.h
+++ b/src/connection_data_logger.h
@@ -67,35 +67,10 @@ protected:
         double interval_;
     };
 
-    /**
-     * @brief Data structure that holds information about variables.
-     */
-    class RecorderInfo
-    {
-    public:
-        RecorderInfo(const Name& name)
-        : name_(name.toString())
-        {
-        };
-
-        RecorderInfo(const std::string& name)
-        : name_(name)
-        {
-        };
-
-        const std::string& get_name() const
-        {
-            return name_;
-        }
-        
-    private:
-        std::string name_;
-    };
-
     recorder_port add_recordable_connection();
 
-    std::vector<RecorderData*> recorder_data_;
-    std::vector<RecorderInfo> recorder_info_;
+    std::vector< RecorderData* > recorder_data_;
+    std::vector< Name > recorder_names_;
 };
 
 /**
@@ -105,13 +80,13 @@ template<typename ConnectionType>
 class ConnectionDataLogger : public ConnectionDataLoggerBase
 {
 public:
-    typedef double ( ConnectionType::*DataAccessFct)() const;
+    typedef double ( ConnectionType::*DataAccessFct )() const;
 
     void register_recordable_variable(const Name& name, DataAccessFct data_access_fct);
     void record(double time, ConnectionType const& host, recorder_port port);
 
 private:
-    std::vector<DataAccessFct> data_access_fct_;
+    std::vector< DataAccessFct > data_access_fct_;
 };
 
 
@@ -129,7 +104,7 @@ template<typename ConnectionType>
 void ConnectionDataLogger<ConnectionType>::register_recordable_variable(const Name& name,
                                                                         DataAccessFct data_access_fct)
 {
-    recorder_info_.push_back(RecorderInfo(name));
+    recorder_names_.push_back(name);
     data_access_fct_.push_back(data_access_fct);
 }
 

--- a/src/connection_data_logger.h
+++ b/src/connection_data_logger.h
@@ -70,14 +70,25 @@ protected:
     /**
      * @brief Data structure that holds information about variables.
      */
-    struct RecorderInfo
+    class RecorderInfo
     {
+    public:
+        RecorderInfo(const Name& name)
+        : name_(name.toString())
+        {
+        };
 
-        RecorderInfo(std::string name)
+        RecorderInfo(const std::string& name)
         : name_(name)
         {
         };
 
+        const std::string& get_name() const
+        {
+            return name_;
+        }
+        
+    private:
         std::string name_;
     };
 
@@ -96,7 +107,7 @@ class ConnectionDataLogger : public ConnectionDataLoggerBase
 public:
     typedef double ( ConnectionType::*DataAccessFct)() const;
 
-    void register_recordable_variable(const std::string& name, DataAccessFct data_access_fct);
+    void register_recordable_variable(const Name& name, DataAccessFct data_access_fct);
     void record(double time, ConnectionType const& host, recorder_port port);
 
 private:
@@ -115,7 +126,7 @@ private:
  * @param data_access_fct pointer to the member function to retrieve the variable.
  */
 template<typename ConnectionType>
-void ConnectionDataLogger<ConnectionType>::register_recordable_variable(const std::string& name,
+void ConnectionDataLogger<ConnectionType>::register_recordable_variable(const Name& name,
                                                                         DataAccessFct data_access_fct)
 {
     recorder_info_.push_back(RecorderInfo(name));

--- a/src/connection_updater.cpp
+++ b/src/connection_updater.cpp
@@ -158,12 +158,9 @@ void ConnectionUpdateManager::update(const nest::Time& time, nest::thread th)
  * @param: syn_id the connection (synapse) type id.
  */
 void ConnectionUpdateManager::register_connector(nest::ConnectorBase* new_conn, nest::ConnectorBase* old_conn,
-                                                 nest::index sender_gid, nest::thread th, nest::ConnectorModel* cm,
-                                                 nest::synindex syn_id)
+                                                 nest::index sender_gid, nest::thread th, nest::synindex syn_id)
 {
-    assert(cm);
-
-    if (connectors_.size() < static_cast<size_t> (th))
+    if (connectors_.size() < (static_cast<size_t> (th)+1))
     {
         throw nest::BadProperty("Connection update manager was not set up correctly before the first call"
                                 " to 'Connect'! Maybe you forgot to call 'InitSynapseUpdater'?");

--- a/src/connection_updater.h
+++ b/src/connection_updater.h
@@ -36,7 +36,6 @@
 #include "event.h"
 #include "node.h"
 #include "nestmodule.h"
-#include "connector_model.h"
 #include "dictdatum.h"
 
 #include "connection_manager_impl.h"
@@ -118,7 +117,7 @@ public:
     void setup(long interval, long exceptable_latency);
 
     void register_connector(nest::ConnectorBase* new_conn, nest::ConnectorBase* old_conn, nest::index sender_gid,
-                            nest::thread th, nest::ConnectorModel* cm, nest::synindex syn_id);
+                            nest::thread th, nest::synindex syn_id);
 
     void trigger_garbage_collector(nest::index target_gid, nest::index sender_gid,
                                    nest::thread target_thread, nest::synindex syn_id);

--- a/src/diligent_connector_model.h
+++ b/src/diligent_connector_model.h
@@ -238,7 +238,7 @@ void DiligentConnectorModel< ConnectionT >::register_connector(nest::ConnectorBa
                                                                nest::synindex syn_id)
 {
     ConnectionUpdateManager::instance()->register_connector(new_conn, old_conn, sender_gid,
-                                                            target_thread, this, syn_id);
+                                                            target_thread, syn_id);
 }
 
 /**

--- a/src/diligent_connector_model.h
+++ b/src/diligent_connector_model.h
@@ -278,7 +278,7 @@ nest::ConnectorBase* DiligentConnectorModel< ConnectionT >::cleanup_delete_conne
     const bool b_has_secondary = has_secondary(conn);
 
     nest::ConnectorBase* conn_vp = validate_pointer(conn);
-    // from here on we can use conn as a valid pointer
+    // from here on we can use conn_vp as a valid pointer
 
     if (conn_vp->homogeneous_model())
     {

--- a/src/poisson_dbl_exp_neuron.cpp
+++ b/src/poisson_dbl_exp_neuron.cpp
@@ -37,6 +37,7 @@
 #include "compose.hpp"
 
 #include "param_utils.h"
+#include "spore_names.h"
 
 
 namespace nest
@@ -80,13 +81,13 @@ template < typename T, typename C >
     p.parameter( v.c_3_, nest::names::c_3, 0.25, pc::MinD(0.0) );
     p.parameter( v.I_e_, nest::names::I_e, 0.0 );
     p.parameter( v.t_ref_remaining_, nest::names::t_ref_remaining, 0.0, pc::MinD(0.0) );
-    p.parameter( v.tau_rise_exc_, "tau_rise_exc", 2.0, pc::BiggerD(0.0) );
-    p.parameter( v.tau_fall_exc_, "tau_fall_exc", 20.0, pc::BiggerD(0.0) );
-    p.parameter( v.tau_rise_inh_, "tau_rise_inh", 1.0, pc::BiggerD(0.0) );
-    p.parameter( v.tau_fall_inh_, "tau_fall_inh", 10.0, pc::BiggerD(0.0) );
-    p.parameter( v.input_conductance_, "input_conductance", 1.0 );
-    p.parameter( v.target_rate_, "target_rate", 10.0, pc::MinD(0.0) );
-    p.parameter( v.target_adaptation_speed_, "target_adaptation_speed", 0.0, pc::MinD(0.0) );
+    p.parameter( v.tau_rise_exc_, names::tau_rise_exc, 2.0, pc::BiggerD(0.0) );
+    p.parameter( v.tau_fall_exc_, names::tau_fall_exc, 20.0, pc::BiggerD(0.0) );
+    p.parameter( v.tau_rise_inh_, names::tau_rise_inh, 1.0, pc::BiggerD(0.0) );
+    p.parameter( v.tau_fall_inh_, names::tau_fall_inh, 10.0, pc::BiggerD(0.0) );
+    p.parameter( v.input_conductance_, names::input_conductance, 1.0 );
+    p.parameter( v.target_rate_, names::target_rate, 10.0, pc::MinD(0.0) );
+    p.parameter( v.target_adaptation_speed_, names::target_adaptation_speed, 0.0, pc::MinD(0.0) );
 }
 
 /**
@@ -145,7 +146,7 @@ r_(0)
 void PoissonDblExpNeuron::State_::get(DictionaryDatum& d, const Parameters_&) const
 {
     def<double>(d, nest::names::V_m, u_membrane_); // Membrane potential
-    def<double>(d, "adaptive_threshold", adaptive_threshold_);
+    def<double>(d, names::adaptive_threshold, adaptive_threshold_);
 }
 
 /**
@@ -154,7 +155,7 @@ void PoissonDblExpNeuron::State_::get(DictionaryDatum& d, const Parameters_&) co
 void PoissonDblExpNeuron::State_::set(const DictionaryDatum& d, const Parameters_&)
 {
     updateValue<double>(d, nest::names::V_m, u_membrane_);
-    updateValue<double>(d, "adaptive_threshold", adaptive_threshold_);
+    updateValue<double>(d, names::adaptive_threshold, adaptive_threshold_);
 }
 
 //

--- a/src/reward_in_proxy.cpp
+++ b/src/reward_in_proxy.cpp
@@ -43,6 +43,7 @@
 #include "music.hh"
 #include "tracing_node.h"
 #include "logging.h"
+#include "spore_names.h"
 
 #include <numeric>
 #include <iterator>
@@ -77,7 +78,7 @@ RewardInProxy::State_::State_()
 void RewardInProxy::Parameters_::get(DictionaryDatum& d) const
 {
     (*d)[ nest::names::port_name ] = port_name_;
-    (*d)[ "delay" ] = delay_;
+    (*d)[ names::delay ] = delay_;
 }
 
 void RewardInProxy::Parameters_::set(const DictionaryDatum& d, State_& s)
@@ -85,7 +86,7 @@ void RewardInProxy::Parameters_::set(const DictionaryDatum& d, State_& s)
     if (!s.published_)
     {
         updateValue< string >(d, nest::names::port_name, port_name_);
-        updateValue< float >(d, "delay", delay_);
+        updateValue< float >(d, names::delay, delay_);
     }
     else
     {

--- a/src/spore_names.cpp
+++ b/src/spore_names.cpp
@@ -71,11 +71,11 @@ const Name reward_gradient("reward_gradient");
 const Name prior_mean("prior_mean");
 const Name prior_precision("prior_precision");
 
-extern const Name eligibility_trace_values("eligibility_trace_values");
-extern const Name psp_values("psp_values");
-extern const Name weight_values("weight_values");
-extern const Name synaptic_parameter_values("synaptic_parameter_values");
-extern const Name reward_gradient_values("reward_gradient_values");
+const Name eligibility_trace_values("eligibility_trace_values");
+const Name psp_values("psp_values");
+const Name weight_values("weight_values");
+const Name synaptic_parameter_values("synaptic_parameter_values");
+const Name reward_gradient_values("reward_gradient_values");
 
 const Name tau_rise_exc("tau_rise_exc");
 const Name tau_fall_exc("tau_fall_exc");

--- a/src/spore_names.cpp
+++ b/src/spore_names.cpp
@@ -1,0 +1,90 @@
+/*
+ * This file is part of SPORE.
+ *
+ * Copyright (C) 2016, the SPORE team (see AUTHORS).
+ *
+ * SPORE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * SPORE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with SPORE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information see: https://github.com/IGITUGraz/spore-nest-module 
+ * 
+ * File:   spore_names.cpp
+ * Author: Kappel
+ *
+ * Created on June 8, 2017, 5:51 PM
+ */
+
+#include "spore_names.h"
+
+namespace spore
+{
+
+namespace names
+{
+const Name trace("trace");
+const Name delay("delay");
+const Name reward_in_proxy("reward_in_proxy");
+
+const Name weight_update_time("weight_update_time");
+const Name bap_trace_id("bap_trace_id");
+const Name recorder_times("recorder_times");
+const Name recorder_interval("recorder_interval");
+const Name recorder_values("recorder_values");
+const Name reset_recorder("reset_recorder");
+const Name test_name("test_name");
+const Name test_time("test_time");
+
+const Name reward_transmitter("reward_transmitter");
+const Name learning_rate("learning_rate");
+const Name episode_length("episode_length");
+const Name psp_tau_rise("psp_tau_rise");
+const Name psp_tau_fall("psp_tau_fall");
+const Name temperature("temperature");
+const Name gradient_noise("gradient_noise");
+const Name max_param("max_param");
+const Name min_param("min_param");
+const Name max_param_change("max_param_change");
+const Name integration_time("integration_time");
+const Name direct_gradient_rate("direct_gradient_rate");
+const Name parameter_mapping_offset("parameter_mapping_offset");
+const Name weight_scale("weight_scale");
+const Name weight_update_interval("weight_update_interval");
+const Name gradient_scale("gradient_scale");
+const Name dopa_trace_id("dopa_trace_id");
+const Name psp_cutoff_amplitude("psp_cutoff_amplitude");
+const Name simulate_retracted_synapses("simulate_retracted_synapses");
+const Name delete_retracted_synapses("delete_retracted_synapses");
+
+const Name synaptic_parameter("synaptic_parameter");
+const Name eligibility_trace("eligibility_trace");
+const Name reward_gradient("reward_gradient");
+const Name prior_mean("prior_mean");
+const Name prior_precision("prior_precision");
+
+extern const Name eligibility_trace_values("eligibility_trace_values");
+extern const Name psp_values("psp_values");
+extern const Name weight_values("weight_values");
+extern const Name synaptic_parameter_values("synaptic_parameter_values");
+extern const Name reward_gradient_values("reward_gradient_values");
+
+const Name tau_rise_exc("tau_rise_exc");
+const Name tau_fall_exc("tau_fall_exc");
+const Name tau_rise_inh("tau_rise_inh");
+const Name tau_fall_inh("tau_fall_inh");
+const Name input_conductance("input_conductance");
+const Name target_rate("target_rate");
+const Name target_adaptation_speed("target_adaptation_speed");
+const Name adaptive_threshold("adaptive_threshold");
+}
+
+}

--- a/src/spore_names.h
+++ b/src/spore_names.h
@@ -1,0 +1,101 @@
+/*
+ * This file is part of SPORE.
+ *
+ * Copyright (C) 2016, the SPORE team (see AUTHORS).
+ *
+ * SPORE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * SPORE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with SPORE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information see: https://github.com/IGITUGraz/spore-nest-module 
+ * 
+ * File:   spore_names.h
+ * Author: Kappel
+ *
+ * Created on June 8, 2017, 5:51 PM
+ */
+
+#ifndef SPORE_NAMES_H
+#define	SPORE_NAMES_H
+
+#include "name.h"
+
+namespace spore
+{
+/**
+ * This namespace contains global Name objects. These can be used in
+ * Node::get_status and Node::set_status to make data exchange
+ * more efficient and consistent. Creating a Name from a std::string
+ * is in O(log n), for n the number of Names already created. Using
+ * predefined names should make data exchange much more efficient.
+ */
+namespace names
+{
+extern const Name trace;
+extern const Name delay;
+extern const Name reward_in_proxy;
+
+extern const Name weight_update_time;
+extern const Name bap_trace_id;
+extern const Name recorder_times;
+extern const Name recorder_interval;
+extern const Name recorder_values;
+extern const Name reset_recorder;
+extern const Name test_name;
+extern const Name test_time;
+
+extern const Name reward_transmitter;
+extern const Name learning_rate;
+extern const Name episode_length;
+extern const Name psp_tau_rise;
+extern const Name psp_tau_fall;
+extern const Name temperature;
+extern const Name gradient_noise;
+extern const Name max_param;
+extern const Name min_param;
+extern const Name max_param_change;
+extern const Name integration_time;
+extern const Name direct_gradient_rate;
+extern const Name parameter_mapping_offset;
+extern const Name weight_scale;
+extern const Name weight_update_interval;
+extern const Name gradient_scale;
+extern const Name dopa_trace_id;
+extern const Name psp_cutoff_amplitude;
+extern const Name simulate_retracted_synapses;
+extern const Name delete_retracted_synapses;
+
+extern const Name synaptic_parameter;
+extern const Name eligibility_trace;
+extern const Name reward_gradient;
+extern const Name prior_mean;
+extern const Name prior_precision;
+
+extern const Name eligibility_trace_values;
+extern const Name psp_values;
+extern const Name weight_values;
+extern const Name synaptic_parameter_values;
+extern const Name reward_gradient_values;
+
+extern const Name tau_rise_exc;
+extern const Name tau_fall_exc;
+extern const Name tau_rise_inh;
+extern const Name tau_fall_inh;
+extern const Name input_conductance;
+extern const Name target_rate;
+extern const Name target_adaptation_speed;
+extern const Name adaptive_threshold;
+}
+
+}
+
+#endif

--- a/src/spore_names.h
+++ b/src/spore_names.h
@@ -25,7 +25,7 @@
  */
 
 #ifndef SPORE_NAMES_H
-#define	SPORE_NAMES_H
+#define SPORE_NAMES_H
 
 #include "name.h"
 

--- a/src/spore_test_connection.h
+++ b/src/spore_test_connection.h
@@ -34,6 +34,7 @@
 #include "spikecounter.h"
 
 #include "tracing_node.h"
+#include "spore_names.h"
 
 
 namespace spore
@@ -76,8 +77,8 @@ public:
      */
     void set_status(const DictionaryDatum& d, nest::ConnectorModel& cm)
     {
-        updateValue<double>(d, "weight_update_time", weight_update_time_);
-        updateValue<long>(d, "bap_trace_id", bap_trace_id_);
+        updateValue<double>(d, names::weight_update_time, weight_update_time_);
+        updateValue<long>(d, names::bap_trace_id, bap_trace_id_);
     }
 
     /**
@@ -246,8 +247,8 @@ template <typename targetidentifierT>
 void SporeTestConnection<targetidentifierT>::get_status(DictionaryDatum& d) const
 {
     ConnectionBase::get_status(d);
-    (*d)["recorder_times"] = recorder_times_;
-    (*d)["recorder_values"] = recorder_values_;
+    (*d)[names::recorder_times] = recorder_times_;
+    (*d)[names::recorder_values] = recorder_values_;
 }
 
 template <typename targetidentifierT>

--- a/src/spore_test_node.h
+++ b/src/spore_test_node.h
@@ -31,6 +31,7 @@
 
 #include "tracing_node.h"
 #include "spore_test_base.h"
+#include "spore_names.h"
 
 namespace spore
 {
@@ -102,8 +103,8 @@ nest::port SporeTestNode::handles_test_event(nest::SpikeEvent&, nest::rport rece
 inline
 void SporeTestNode::get_status(DictionaryDatum& d) const
 {
-    def<std::string>(d, "test_name", test_name_);
-    def<double>(d, "test_time", test_time_);
+    def<std::string>(d, names::test_name, test_name_);
+    def<double>(d, names::test_time, test_time_);
     if (not test_name_.empty())
     {
         const SporeTestBase* test = tests_.at(test_name_);
@@ -119,7 +120,7 @@ inline
 void SporeTestNode::set_status(const DictionaryDatum &d)
 {
     std::string test_name;
-    if (updateValue<std::string>(d, "test_name", test_name))
+    if (updateValue<std::string>(d, names::test_name, test_name))
     {
         if (tests_.find(test_name) == tests_.end())
             throw nest::BadParameter("test '" + test_name + "' does not exist!");
@@ -128,7 +129,7 @@ void SporeTestNode::set_status(const DictionaryDatum &d)
     }
 
 
-    updateValue<double>(d, "test_time", test_time_);
+    updateValue<double>(d, names::test_time, test_time_);
 
     if (not test_name_.empty())
     {

--- a/src/sporemodule.cpp
+++ b/src/sporemodule.cpp
@@ -160,7 +160,7 @@ void spore::SporeModule::init(SLIInterpreter* i)
     nest::kernel().model_manager.register_node_model<RewardInProxy>("reward_in_proxy");
 
     ConnectionUpdateManager::instance()->init(cu_model_id);
-    
+
     spore::register_diligent_connection_model
             < SynapticSamplingRewardGradientConnection<nest::TargetIdentifierPtrRport> >
             ("synaptic_sampling_rewardgradient_synapse");

--- a/src/sporemodule.cpp
+++ b/src/sporemodule.cpp
@@ -160,7 +160,7 @@ void spore::SporeModule::init(SLIInterpreter* i)
     nest::kernel().model_manager.register_node_model<RewardInProxy>("reward_in_proxy");
 
     ConnectionUpdateManager::instance()->init(cu_model_id);
-
+    
     spore::register_diligent_connection_model
             < SynapticSamplingRewardGradientConnection<nest::TargetIdentifierPtrRport> >
             ("synaptic_sampling_rewardgradient_synapse");

--- a/src/synaptic_sampling_rewardgradient_connection.cpp
+++ b/src/synaptic_sampling_rewardgradient_connection.cpp
@@ -40,26 +40,26 @@ namespace spore
 template < typename T, typename C >
     static void define_parameters( T& p, C& v )
 {
-    p.parameter( v.learning_rate_, "learning_rate", 5e-08, pc::MinD(0.0) );
-    p.parameter( v.episode_length_, "episode_length", 1000.0, pc::BiggerD(0.0) );
-    p.parameter( v.psp_tau_rise_, "psp_tau_rise", 2.0, pc::BiggerD(0.0) );
-    p.parameter( v.psp_tau_fall_, "psp_tau_fall", 20.0, pc::BiggerD(0.0) );
-    p.parameter( v.temperature_, "temperature", 0.1, pc::MinD(0.0) );
-    p.parameter( v.gradient_noise_, "gradient_noise", 0.0, pc::MinD(0.0) );
-    p.parameter( v.max_param_, "max_param", 5.0 );
-    p.parameter( v.min_param_, "min_param", -2.0 );
-    p.parameter( v.max_param_change_, "max_param_change", 40.0, pc::MinD(0.0) );
-    p.parameter( v.integration_time_, "integration_time", 50000.0, pc::BiggerD(0.0) );
-    p.parameter( v.direct_gradient_rate_, "direct_gradient_rate", 0.0 );
-    p.parameter( v.parameter_mapping_offset_, "parameter_mapping_offset", 3.0 );
-    p.parameter( v.weight_scale_, "weight_scale", 1.0 );
-    p.parameter( v.weight_update_interval_, "weight_update_interval", 100.0, pc::BiggerD(0.0) );
-    p.parameter( v.gradient_scale_, "gradient_scale", 1.0 );
-    p.parameter( v.bap_trace_id_, "bap_trace_id", 0l, pc::MinL(0) );
-    p.parameter( v.dopa_trace_id_, "dopa_trace_id", 0l, pc::MinL(0) );
-    p.parameter( v.psp_cutoff_amplitude_, "psp_cutoff_amplitude", 0.0001, pc::MinD(0) );
-    p.parameter( v.simulate_retracted_synapses_, "simulate_retracted_synapses", false );
-    p.parameter( v.delete_retracted_synapses_, "delete_retracted_synapses", false );
+    p.parameter( v.learning_rate_, names::learning_rate, 5e-08, pc::MinD(0.0) );
+    p.parameter( v.episode_length_, names::episode_length, 1000.0, pc::BiggerD(0.0) );
+    p.parameter( v.psp_tau_rise_, names::psp_tau_rise, 2.0, pc::BiggerD(0.0) );
+    p.parameter( v.psp_tau_fall_, names::psp_tau_fall, 20.0, pc::BiggerD(0.0) );
+    p.parameter( v.temperature_, names::temperature, 0.1, pc::MinD(0.0) );
+    p.parameter( v.gradient_noise_, names::gradient_noise, 0.0, pc::MinD(0.0) );
+    p.parameter( v.max_param_, names::max_param, 5.0 );
+    p.parameter( v.min_param_, names::min_param, -2.0 );
+    p.parameter( v.max_param_change_, names::max_param_change, 40.0, pc::MinD(0.0) );
+    p.parameter( v.integration_time_, names::integration_time, 50000.0, pc::BiggerD(0.0) );
+    p.parameter( v.direct_gradient_rate_, names::direct_gradient_rate, 0.0 );
+    p.parameter( v.parameter_mapping_offset_, names::parameter_mapping_offset, 3.0 );
+    p.parameter( v.weight_scale_, names::weight_scale, 1.0 );
+    p.parameter( v.weight_update_interval_, names::weight_update_interval, 100.0, pc::BiggerD(0.0) );
+    p.parameter( v.gradient_scale_, names::gradient_scale, 1.0 );
+    p.parameter( v.bap_trace_id_, names::bap_trace_id, 0l, pc::MinL(0) );
+    p.parameter( v.dopa_trace_id_, names::dopa_trace_id, 0l, pc::MinL(0) );
+    p.parameter( v.psp_cutoff_amplitude_, names::psp_cutoff_amplitude, 0.0001, pc::MinD(0) );
+    p.parameter( v.simulate_retracted_synapses_, names::simulate_retracted_synapses, false );
+    p.parameter( v.delete_retracted_synapses_, names::delete_retracted_synapses, false );
 }
 
 /**
@@ -101,11 +101,11 @@ void SynapticSamplingRewardGradientCommonProperties::get_status(DictionaryDatum&
 
     if (reward_transmitter_ != 0)
     {
-        def<long>(d, "reward_transmitter", reward_transmitter_->get_gid());
+        def<long>(d, names::reward_transmitter, reward_transmitter_->get_gid());
     }
     else
     {
-        def<long>(d, "reward_transmitter", -1);
+        def<long>(d, names::reward_transmitter, -1);
     }
 }
 
@@ -120,7 +120,7 @@ void SynapticSamplingRewardGradientCommonProperties::set_status(const Dictionary
     define_parameters < CheckParameters > ( p_check, *this );
 
     long rtgid;
-    if (updateValue<long>(d, "reward_transmitter", rtgid))
+    if (updateValue<long>(d, names::reward_transmitter, rtgid))
     {
         TracingNode* new_reward_transmitter = dynamic_cast<TracingNode*> (nest::kernel().node_manager.get_node(rtgid));
 

--- a/src/synaptic_sampling_rewardgradient_connection.h
+++ b/src/synaptic_sampling_rewardgradient_connection.h
@@ -561,6 +561,8 @@ ConnectionDataLogger< SynapticSamplingRewardGradientConnection<targetidentifierT
 
 /**
  * Get the data logger singleton.
+ * 
+ * @note Instantiating the logger for the first time may not be thread save.
  *
  * @return the instance of the data logger.
  */

--- a/src/synaptic_sampling_rewardgradient_connection.h
+++ b/src/synaptic_sampling_rewardgradient_connection.h
@@ -38,6 +38,7 @@
 #include "tracing_node.h"
 #include "connection_updater.h"
 #include "connection_data_logger.h"
+#include "spore_names.h"
 
 
 namespace spore
@@ -375,6 +376,7 @@ public:
     void set_status(const DictionaryDatum& d, nest::ConnectorModel& cm);
 
     void send(nest::Event& e, nest::thread t, double t_lastspike, const CommonPropertiesType& cp);
+    void check_synapse_params( const DictionaryDatum& syn_spec ) const;
 
     using ConnectionBase::get_delay_steps;
     using ConnectionBase::get_delay;
@@ -566,16 +568,16 @@ ConnectionDataLogger< SynapticSamplingRewardGradientConnection<targetidentifierT
     {
         logger_ = new ConnectionDataLogger<SynapticSamplingRewardGradientConnection>();
 
-        logger_->register_recordable_variable("eligibility_trace",
-                                              &SynapticSamplingRewardGradientConnection::get_eligibility_trace);
-        logger_->register_recordable_variable("psp",
-                                              &SynapticSamplingRewardGradientConnection::get_psp);
-        logger_->register_recordable_variable("weight",
-                                              &SynapticSamplingRewardGradientConnection::get_weight);
-        logger_->register_recordable_variable("synaptic_parameter",
-                                              &SynapticSamplingRewardGradientConnection::get_synaptic_parameter);
-        logger_->register_recordable_variable("reward_gradient",
-                                              &SynapticSamplingRewardGradientConnection::get_reward_gradient);
+        //logger_->register_recordable_variable(names::eligibility_trace_values,
+        //                                      &SynapticSamplingRewardGradientConnection::get_eligibility_trace);
+        //logger_->register_recordable_variable(names::psp_values,
+        //                                      &SynapticSamplingRewardGradientConnection::get_psp);
+        //logger_->register_recordable_variable(names::weight_values,
+        //                                      &SynapticSamplingRewardGradientConnection::get_weight);
+        //logger_->register_recordable_variable(names::synaptic_parameter_values,
+        //                                      &SynapticSamplingRewardGradientConnection::get_synaptic_parameter);
+        //logger_->register_recordable_variable(names::reward_gradient_values,
+        //                                      &SynapticSamplingRewardGradientConnection::get_reward_gradient);
     }
 
     return logger_;
@@ -586,6 +588,17 @@ ConnectionDataLogger< SynapticSamplingRewardGradientConnection<targetidentifierT
 //
 
 /**
+ * Check syn_spec dictionary for parameters that are not allowed for this
+ * connection. Will issue warning or throw error if a parameter is found.
+ */
+template <typename targetidentifierT>
+void SynapticSamplingRewardGradientConnection<targetidentifierT>::check_synapse_params(const DictionaryDatum& syn_spec)
+    const
+{
+    // FIXME!! Check synaptic parameters here!
+}
+
+/**
  * Status getter function.
  */
 template <typename targetidentifierT>
@@ -593,11 +606,11 @@ void SynapticSamplingRewardGradientConnection<targetidentifierT>::get_status(Dic
 {
     ConnectionBase::get_status(d);
     def<double>(d, nest::names::weight, weight_);
-    def<double>(d, "synaptic_parameter", synaptic_parameter_);
-    def<double>(d, "eligibility_trace", eligibility_trace_);
-    def<double>(d, "reward_gradient", reward_gradient_);
-    def<double>(d, "prior_mean", prior_mean_);
-    def<double>(d, "prior_precision", prior_precision_);
+    def<double>(d, names::synaptic_parameter, synaptic_parameter_);
+    def<double>(d, names::eligibility_trace, eligibility_trace_);
+    def<double>(d, names::reward_gradient, reward_gradient_);
+    def<double>(d, names::prior_mean, prior_mean_);
+    def<double>(d, names::prior_precision, prior_precision_);
     def<long>(d, nest::names::size_of, sizeof (*this));
 
     logger()->get_status(d, recorder_port_);
@@ -614,9 +627,9 @@ void SynapticSamplingRewardGradientConnection<targetidentifierT>::set_status(con
 {
     ConnectionBase::set_status(d, cm);
     updateValue<double>(d, nest::names::weight, weight_);
-    updateValue<double>(d, "synaptic_parameter", synaptic_parameter_);
-    updateValue<double>(d, "prior_mean", prior_mean_);
-    updateValue<double>(d, "prior_precision", prior_precision_);
+    updateValue<double>(d, names::synaptic_parameter, synaptic_parameter_);
+    updateValue<double>(d, names::prior_mean, prior_mean_);
+    updateValue<double>(d, names::prior_precision, prior_precision_);
 
     logger()->set_status(d, recorder_port_);
 }

--- a/src/synaptic_sampling_rewardgradient_connection.h
+++ b/src/synaptic_sampling_rewardgradient_connection.h
@@ -515,6 +515,8 @@ prior_mean_(0.0),
 prior_precision_(1.0),
 recorder_port_(nest::invalid_index)
 {
+    // make sure the global logger object is instantiated here.
+    logger();
 }
 
 /**
@@ -534,6 +536,8 @@ prior_mean_(rhs.prior_mean_),
 prior_precision_(rhs.prior_precision_),
 recorder_port_(nest::invalid_index)
 {
+    // make sure the global logger object is instantiated here.
+    logger();
 }
 
 /**
@@ -568,16 +572,18 @@ ConnectionDataLogger< SynapticSamplingRewardGradientConnection<targetidentifierT
     {
         logger_ = new ConnectionDataLogger<SynapticSamplingRewardGradientConnection>();
 
-        //logger_->register_recordable_variable(names::eligibility_trace_values,
-        //                                      &SynapticSamplingRewardGradientConnection::get_eligibility_trace);
-        //logger_->register_recordable_variable(names::psp_values,
-        //                                      &SynapticSamplingRewardGradientConnection::get_psp);
-        //logger_->register_recordable_variable(names::weight_values,
-        //                                      &SynapticSamplingRewardGradientConnection::get_weight);
-        //logger_->register_recordable_variable(names::synaptic_parameter_values,
-        //                                      &SynapticSamplingRewardGradientConnection::get_synaptic_parameter);
-        //logger_->register_recordable_variable(names::reward_gradient_values,
-        //                                      &SynapticSamplingRewardGradientConnection::get_reward_gradient);
+        logger_->register_recordable_variable(names::eligibility_trace_values,
+                                              &SynapticSamplingRewardGradientConnection::get_eligibility_trace);
+        logger_->register_recordable_variable(names::psp_values,
+                                              &SynapticSamplingRewardGradientConnection::get_psp);
+
+        logger_->register_recordable_variable(names::weight_values,
+                                              &SynapticSamplingRewardGradientConnection::get_weight);
+
+        logger_->register_recordable_variable(names::synaptic_parameter_values,
+                                              &SynapticSamplingRewardGradientConnection::get_synaptic_parameter);
+        logger_->register_recordable_variable(names::reward_gradient_values,
+                                              &SynapticSamplingRewardGradientConnection::get_reward_gradient);
     }
 
     return logger_;

--- a/src/tracing_node.cpp
+++ b/src/tracing_node.cpp
@@ -26,6 +26,7 @@
 
 #include "tracing_node.h"
 #include "connection_updater.h"
+#include "spore_names.h"
 
 #include "kernel_manager.h"
 #include "arraydatum.h"
@@ -97,7 +98,7 @@ void TracingNode::get_trace_status(DictionaryDatum& d) const
         }
         traces.push_back(trace);
     }
-    (*d)["trace"] = traces;
+    (*d)[names::trace] = traces;
 }
 
 }


### PR DESCRIPTION
This is a fix to issue #17. c-string arguments have been changed to Name object. This was necessary because NEST no longer allows Name objects to be build "on the fly" when multi-threading is turned on. 

In the current commit, there is still a problem with the connection recorder object that needs to be adapted to work with Name object.